### PR TITLE
Fix compensation create route

### DIFF
--- a/CodeChallenge/Controllers/CompensationController.cs
+++ b/CodeChallenge/Controllers/CompensationController.cs
@@ -86,7 +86,7 @@ public class CompensationController : ControllerBase
             }
 
             _logger.LogInformation("Successfully created compensation record for EmployeeId '{EmployeeId}'", compensation.EmployeeId);
-            return CreatedAtRoute("getCompensationByEmployeeById", new { id = compensation.CompensationId}, compensation);
+            return CreatedAtRoute("getCompensationByEmployeeById", new { id = compensation.EmployeeId }, compensation);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- fix CreatedAtRoute parameter when creating compensation

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68558f1e0cc8832ebc2f2753679f253c